### PR TITLE
LF-16837: Fix bug where WallComponent wouldnt respect opts.initial of e.g. 10

### DIFF
--- a/src/wall-view.js
+++ b/src/wall-view.js
@@ -261,7 +261,9 @@ define([
      * @returns {Number} The number of maximum visible items for a given column view
      */
     MediaWallView.prototype._getMaxVisibleItemsForColumn = function () {
-        return this._maxVisibleItems/this._numberOfColumns;
+        // The maxVisibleItems feature isn't really relevant for the
+        // columnViews. All that is managed by the MediaWallView itself
+        return Infinity;
     };
 
     MediaWallView.prototype._attachColumnView = function (columnView) {

--- a/tests/spec/wall-component.js
+++ b/tests/spec/wall-component.js
@@ -7,6 +7,7 @@ var WallComponent = require('streamhub-wall/wall-component');
 var MockCollection = require('streamhub-sdk-tests/mocks/collection/mock-collection');
 var packageAttribute = require('streamhub-wall/package-attribute');
 var auth = require('auth');
+var Content = require('streamhub-sdk/content');
 
 describe('A MediaWallComponent', function () {
     beforeEach(function () {
@@ -33,6 +34,28 @@ describe('A MediaWallComponent', function () {
         wall.render();
         expect(wall.$('.streamhub-wall-component').length).toBe(1);
     });
+    it('can be constructed with opts.initial: 10', function () {
+        var INITIAL = 10;
+        var wall = new WallComponent({
+            initial: INITIAL,
+            columns: 4
+        });
+        var totalToAdd = 20;
+        var toAdd = totalToAdd;
+        var written = 0;
+        while (toAdd--) {
+            wall.more.write(new Content({ body: 'what'+toAdd }), function (err) {
+                written++;
+            });
+        }
+        waitsFor(function () {
+            return written >= INITIAL;
+        });
+        runs(function () {
+            var numRendered = wall._wallView.$('.content').length;
+            expect(numRendered).toBe(INITIAL);
+        })
+    })
     describe('opts.collection', function () {
         it('can be just a POJO', function () {
             var collectionOpts = {


### PR DESCRIPTION
The inner ColumnViews were being configured to only render like 2.5 items before 'holding onto' further writes.

That maxVisibleItems state is really only meant for 'outermost' ListViews, not inner ones. So now the columns get built with maxVisibleItems: Infinity.

There is also a test that failed before but now passes.
