### PR TITLE
LF-21155 enabling the new multiple images view from sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,12 @@ env=dev
 deploy: dist
 	./node_modules/.bin/lfcdn -e $(env)
 
-dist: build src requirejs.conf.js tools
+dist: build src requirejs.conf.js tools lint
 	mkdir -p dist
 	./node_modules/requirejs/bin/r.js -o ./tools/build.conf.js
+
+lint:
+	npm run lint
 
 # if package.json changes, install
 node_modules: package.json
@@ -29,15 +32,3 @@ server: build
 
 test: build
 	npm test
-
-lint:
-	npm run lint
-
-clean:
-	rm -rf node_modules lib dist
-
-package: build
-
-env=dev
-deploy: dist
-	./node_modules/.bin/lfcdn -e $(env)

--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,11 @@
 {
   "name": "streamhub-wall",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "main": [
     "./src/main.js"
   ],
   "dependencies": {
-    "streamhub-sdk": "git://github.com/Livefyre/streamhub-sdk.git#2.20.0",
+    "streamhub-sdk": "git://github.com/Livefyre/streamhub-sdk.git#2.21.0",
     "cajon": "git://github.com/requirejs/cajon.git#~0.1.11",
     "streamhub-input": "Livefyre/streamhub-input#0.7.4",
     "rework": "gobengo/rework#~0.21.0",
@@ -36,6 +36,6 @@
     "mout": "0.11.0",
     "cajon": "~0.1.11",
     "streamhub-share": "0.3.0",
-    "streamhub-sdk": "2.20.0"
+    "streamhub-sdk": "2.21.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "streamhub-wall",
   "description": "Livefyre LiveMediaWall",
   "author": "Livefyre <support@livefyre.com>",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "devDependencies": {
     "bower": "1.3.8",
     "csso": "^1.3.11",

--- a/src/wall-view.js
+++ b/src/wall-view.js
@@ -44,7 +44,7 @@ define([
       this.setColumns(opts.columns);
     }
 
-    opts.singleMediaView = true;
+    opts.useSingleMediaView = true;
 
     ContentListView.call(this, opts);
 

--- a/src/wall-view.js
+++ b/src/wall-view.js
@@ -44,8 +44,10 @@ define([
       this.setColumns(opts.columns);
     }
 
+    opts.singleMediaView = true;
+
     ContentListView.call(this, opts);
-    
+
     if (this.modal) {
       // Patch the modal so that it has the right package selector when it
       // is shown (like data-lf-package="streamhub-wall#3.0.0")


### PR DESCRIPTION
We need to attach an streamhub-sdk version after Livefyre/streamhub-sdk#354 has been merged and this is ready to be merged.